### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/golang/redis/docker-compose.yml
+++ b/golang/redis/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - redis-sentinel_data:/bitnami
   redis:
-    image: docker.io/bitnami/redis:6.2
+    image: docker.io/soldevelo/redis:6.2
     container_name: redis
     ports:
       - 6379:6379

--- a/postgresql/docker-compose.yml
+++ b/postgresql/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     driver: bridge
 services:
   pg-0:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     ports:
       - 5432
     volumes:
@@ -21,7 +21,7 @@ services:
       - REPMGR_NODE_NAME=pg-0
       - REPMGR_NODE_NETWORK_NAME=pg-0
   pg-1:
-    image: bitnami/postgresql-repmgr:14
+    image: soldevelo/postgresql-repmgr:14
     ports:
       - 5432
     volumes:
@@ -37,7 +37,7 @@ services:
       - REPMGR_NODE_NAME=pg-1
       - REPMGR_NODE_NETWORK_NAME=pg-1
   pgpool:
-    image: bitnami/pgpool:4
+    image: soldevelo/pgpool:4
     ports:
       - ${VIP}:5432:5432
     environment:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/postgresql-repmgr:14` → [`soldevelo/postgresql-repmgr:14`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)
- `bitnami/pgpool:4` → [`soldevelo/pgpool:4`](https://hub.docker.com/r/soldevelo/pgpool)
- `bitnami/redis:6.2` → [`soldevelo/redis:6.2`](https://hub.docker.com/r/soldevelo/redis)

## Summary by Sourcery

Update container image references to use maintained SolDevelo equivalents instead of deprecated Bitnami images in docker-compose configurations.

Build:
- Switch PostgreSQL repmgr and PgPool services in postgresql/docker-compose.yml from Bitnami to SolDevelo images.
- Switch Redis service in golang/redis/docker-compose.yml from Bitnami to the SolDevelo image.